### PR TITLE
Removes SSH key requirement

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,7 @@
 
 ### Section of variable declarations ###
 
-# this requires that user has setup SSH key on Github
-git_upstream_repo=git@github.com:KhronosGroup/Vulkan-Docs.git
+git_upstream_repo=https://github.com/KhronosGroup/Vulkan-Docs.git
 repo_dir=Vulkan-Docs
 target_api_version_release=
 is_need_fetch_latest_tag_release=0


### PR DESCRIPTION
Thanks for making this! I was really missing being able to quickly pull up man pages from OpenGL.

---

I tested this PR on a one-off CI job on builds.sr.ht: https://builds.sr.ht/~remexre/job/195813

If you wanna snag that build config and set up automated builds on either builds.sr.ht, or another platform, it'd be nice to be able to just download a tarball or whatever from CI instead of having to build it oneself.